### PR TITLE
Made the Renderer work well on resized browser windows.

### DIFF
--- a/examples/shared/style.css
+++ b/examples/shared/style.css
@@ -24,7 +24,6 @@ a:hover {
   margin-left: auto;
   margin-right: auto;
   display: block;
-  width: 1280px;
 }
 
 #display {

--- a/examples/simple/.#index.html
+++ b/examples/simple/.#index.html
@@ -1,1 +1,0 @@
-david@davidbuntu.5541:1382525261

--- a/examples/simple/.#index.html
+++ b/examples/simple/.#index.html
@@ -1,0 +1,1 @@
+david@davidbuntu.5541:1382525261

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -27,14 +27,6 @@
 <script src='../../src/renderer.js'></script>
 
 <script>
-  window.onresize = function(e) {
-    var canvas = document.getElementById('display');
-    canvas.width = window.innerWidth - 200;
-    canvas.height = window.innerHeight - 200;
-  };
-
-  window.onresize();
- 
   var renderer = Newton.Renderer(document.getElementById('display'));
   var sim = Newton.Simulator(simulate, renderer.callback, 60);
   var particles = Newton.Body();

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -7,7 +7,7 @@
 <body>
 
 <div class='wrap'>
-  <canvas id="display" width="1280" height="450"></canvas>
+  <center><canvas id="display"></canvas></center>
 </div>
 
 <script type="text/javascript" src="../../vendor/jquery-2.0.3.js"></script>
@@ -27,7 +27,14 @@
 <script src='../../src/renderer.js'></script>
 
 <script>
+  window.onresize = function(e) {
+    var canvas = document.getElementById('display');
+    canvas.width = window.innerWidth - 200;
+    canvas.height = window.innerHeight - 200;
+  };
 
+  window.onresize();
+ 
   var renderer = Newton.Renderer(document.getElementById('display'));
   var sim = Newton.Simulator(simulate, renderer.callback, 60);
   var particles = Newton.Body();

--- a/examples/simple/index.html
+++ b/examples/simple/index.html
@@ -7,7 +7,7 @@
 <body>
 
 <div class='wrap'>
-  <center><canvas id="display"></canvas></center>
+  <canvas id="display" style="display: block; margin-left: auto; margin-right: auto;"></canvas>
 </div>
 
 <script type="text/javascript" src="../../vendor/jquery-2.0.3.js"></script>
@@ -27,6 +27,14 @@
 <script src='../../src/renderer.js'></script>
 
 <script>
+  window.onresize = function(e) {
+    var canvas = document.getElementById('display');
+    canvas.width = window.innerWidth - 200;
+    canvas.height = window.innerHeight - 200;
+  };
+
+  window.onresize();
+ 
   var renderer = Newton.Renderer(document.getElementById('display'));
   var sim = Newton.Simulator(simulate, renderer.callback, 60);
   var particles = Newton.Body();
@@ -48,7 +56,6 @@
       accumulator -= 250;
     }
   }
-
 </script>
 
 </body>

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -4,7 +4,7 @@
     if (!(this instanceof Renderer)) return new Renderer(el);
     var self = this;
     this.el = el;
-    this.ctx = el.getContext('2d');
+    this.ctx = this.el.getContext('2d');
     this.width = el.width;
     this.height = el.height;
     this.callback = this.callback.bind(this); // TODO: shim for Function.bind
@@ -95,11 +95,3 @@
   window.Newton.Renderer = Renderer;
 
 })();
-
-window.onresize = function(e) {
-  var canvas = document.getElementById('display');
-  canvas.width = window.innerWidth - 200;
-  canvas.height = window.innerHeight - 200;
-};
-
-window.onresize();

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,6 +3,7 @@
   function Renderer(el) {
     if (!(this instanceof Renderer)) return new Renderer(el);
     var self = this;
+    this.el = el;
     this.ctx = el.getContext('2d');
     this.width = el.width;
     this.height = el.height;
@@ -27,7 +28,7 @@
     clear: function(ctx, time) {
       ctx.save();
       ctx.fillStyle = '#000000';
-      ctx.fillRect(0, 0, this.width, this.height);
+      ctx.fillRect(0, 0, this.el.width, this.el.height);
       ctx.restore();
     },
     drawParticles: function(ctx, particles) {
@@ -94,3 +95,11 @@
   window.Newton.Renderer = Renderer;
 
 })();
+
+window.onresize = function(e) {
+  var canvas = document.getElementById('display');
+  canvas.width = window.innerWidth - 200;
+  canvas.height = window.innerHeight - 200;
+};
+
+window.onresize();


### PR DESCRIPTION
Basically, when I resized the demo the canvas wouldn't show properly and this fixes that issue.

It's only natural a user might resize his window while he's playing a game or doing something else, so the Renderer should be careful about it.
