### PR TITLE
Adding Examples links to Readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -225,6 +225,10 @@ layer.addForce(gravity);
 
 ## Examples
 
+- [Simple](http://hunterloftis.github.io/newton/examples/simple)
+- [Particles](http://hunterloftis.github.io/newton/examples/particles)
+- ~~[Boxes](http://hunterloftis.github.io/newton/examples/boxes)~~ (Broken)
+
 ## The nerdy details
 
 Physics major?


### PR DESCRIPTION
Boxes is currently broken (listed with a strikethrough), while Shared doesn't have any HTML and has been excluded from the list.
