### PR TITLE
grunt: added target to get one file newton

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,28 @@
+module.exports = function(grunt) {
+
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+
+    grunt.initConfig({
+      uglify: {
+        newton_min: {
+          files: {
+            'newton.min.js': ['src/**/*.js']
+          }
+        },
+        newton: {
+          files: {
+            'newton.js': ['src/**/*.js']
+          },
+          options: {
+            beautify: {
+              width: 80,
+              beautify: true
+            }
+          }
+        }
+      }
+    });
+
+    grunt.registerTask('default', ['uglify']);
+
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "newton",
+  "version": "0.0.0",
+  "description": "An easy-to-use, feature-rich physics engine that's designed from the ground up for JavaScript.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hunterloftis/newton"
+  },
+  "devDependencies": {
+    "grunt-contrib-uglify": "0.2.x",
+    "grunt": "0.4.x"
+  },
+  "author": "",
+  "license": "MIT",
+  "readmeFilename": "readme.md",
+  "bugs": {
+    "url": "https://github.com/hunterloftis/newton/issues"
+  }
+}


### PR DESCRIPTION
It's always nice to have minified version of js library, right?

To build single `newton.js` file run this in console:

``` bash
npm install
grunt
```

P.s. If you don't have npm installed - you can get it [right here](http://nodejs.org/download/) or install from repository (if you have ubuntu or homebrew)
