### PR TITLE
pixi: tune up readme for pixi renderer

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,10 +112,21 @@ function renderFn(time, simulator) {}
 
 You can render the scene however you like by providing a render function
 that takes the arguments *(frameTimeInMs, simulator)*. However, it's often convenient to
-have a default renderer for quick development. Newton provides one based on Canvas:
+have a default renderer for quick development. Newton provides two renderers:
+
+One based on Canvas:
 
 ```js
+// viewport - is a Canvas element
 var renderer = Newton.Renderer(document.getElementById('viewport'));
+var sim = Newton.Simulator(null, renderer.callback);
+```
+
+And based on WebGL (you will need to include [Pixi](https://github.com/GoodBoyDigital/pixi.js) library into web page):
+
+```js
+// viewport - is a Div element
+var renderer = Newton.PixiRenderer(document.getElementById('viewport'), 800, 600);
 var sim = Newton.Simulator(null, renderer.callback);
 ```
 


### PR DESCRIPTION
On a second thought - may be it's good idea to move PIXI.Stage creation out of constructor to make the method signatures of Newton.Renderer and Newton.PixiRenderer look similar.
